### PR TITLE
bobuino/pins_arduino.h: removed problematic extern declarations; fixed analogInputToDigitalPin()...

### DIFF
--- a/variants/bobuino/pins_arduino.h~
+++ b/variants/bobuino/pins_arduino.h~
@@ -31,7 +31,11 @@
 
 #define NUM_DIGITAL_PINS            32
 #define NUM_ANALOG_INPUTS           8
-#define analogInputToDigitalPin(p)  ((p < NUM_ANALOG_INPUTS) ? (p) + 14 : -1)
+#define analogInputToDigitalPin(p)  ((p < NUM_ANALOG_INPUTS) ? 21 - (p) : -1)
+
+extern const uint8_t digital_pin_to_pcint[NUM_DIGITAL_PINS];
+extern const uint16_t __pcmsk[];
+extern const uint8_t digital_pin_to_timer_PGM[NUM_DIGITAL_PINS];
 
 #define ifpin(p,what,ifnot)	    (((p) >= 0 && (p) < NUM_DIGITAL_PINS) ? (what) : (ifnot))
 #define digitalPinHasPWM(p)         ifpin(p,pgm_read_byte(digital_pin_to_timer_PGM + (p)) != NOT_ON_TIMER,1==0)


### PR DESCRIPTION
... macro

"extern" declarations for arrays defined in the pins_arduino.h file were
causing link errors when those symbols needed to be resolved. The
declarations just needed deleting.

Fixed analogInputToDigitalPin() macro. It was mapping e.g. A0 -> D21 and
A7 -> D14, which was incorrect. The correct mapping is A0 -> D14 ... A7
-> D21.
