### PR TITLE
Remove 2 'Original' boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -71,38 +71,3 @@ bobuino.build.f_cpu=16000000L
 bobuino.build.core=mighty
 bobuino.build.variant=bobuino
 
-##############################################################
-
-mighty.name=Original Mighty 1284p 16MHz
-mighty.upload.protocol=stk500v1
-mighty.upload.maximum_size=129024
-mighty.upload.speed=57600
-mighty.bootloader.low_fuses=0xff
-mighty.bootloader.high_fuses=0xdc
-mighty.bootloader.extended_fuses=0xfd
-mighty.bootloader.path=standard
-mighty.bootloader.file=ATmegaBOOT_1284P.hex
-mighty.bootloader.unlock_bits=0x3F
-mighty.bootloader.lock_bits=0x0F
-mighty.build.mcu=atmega1284p
-mighty.build.f_cpu=16000000L
-mighty.build.core=mighty
-mighty.build.variant=standard
-
-##############################################################
-
-mighty8.name=Original Mighty 1284p 8MHz
-mighty8.upload.protocol=stk500v1
-mighty8.upload.maximum_size=129024
-mighty8.upload.speed=28800
-mighty8.bootloader.low_fuses=0xff
-mighty8.bootloader.high_fuses=0xdc
-mighty8.bootloader.extended_fuses=0xfd
-mighty8.bootloader.path=standard
-mighty8.bootloader.file=ATmegaBOOT_1284P_8MHz.hex
-mighty8.bootloader.unlock_bits=0x3F
-mighty8.bootloader.lock_bits=0x0F
-mighty8.build.mcu=atmega1284p
-mighty8.build.f_cpu=8000000L
-mighty8.build.core=mighty
-mighty8.build.variant=standard


### PR DESCRIPTION
Maniacbug said the two 'Original' boards were only for reference two years ago, so I doubt that there is an ongoing need to include them. I suggest removing them for cleanliness and to avoid confusion for new users. Closes #4 and #5.
