### PR TITLE
Add alternative boards.txt file

### DIFF
--- a/avr/boards.txt.alt
+++ b/avr/boards.txt.alt
@@ -1,0 +1,173 @@
+# This an alternative boards.txt for mighty-1284p that offers more board/clock settings combinations 
+# for more advanced users. Instead of either one or two preselected clock setting options available
+# from the menu for each board, with this boards.txt there are now all clock settings available for 
+# all boards listed, as the board and the clock setting are selected independently from separate sub-menus.
+# 16Mhz Low Power and 20Mhz Full Swing clock settings have not been tested with all ATmega1284P based
+# boards and may cause unstable operation.
+#
+# Note that the board has to have the matching bootloader burned to the board with an ISP programmer before 
+# that board/clock setting combination will work at build/upload time. E.g., if changing from 16MHz full swing 
+# clock to an 8MHz internal clock, the appropriate board and clock settings will have to be selected before 
+# the "burn bootloader" operation is performed again.
+#
+# To install and use this alternative boards.txt file, simply rename the default boards.txt to boards.txt.std,
+# and then rename this file to boards.txt. Restart the IDE, and you will see the additional "clock" sub-menus 
+# appear under the board menu when one of the mighty-1284p board types is selected.
+#
+# -May, 2015.
+
+menu.clock=Clock
+
+##############################################################
+
+avr_developers.name=avr-developers.com pinout
+avr_developers.upload.tool=arduino:avrdude
+avr_developers.upload.protocol=arduino
+avr_developers.upload.maximum_data_size=16384
+avr_developers.upload.maximum_size=130048
+avr_developers.bootloader.tool=arduino:avrdude
+avr_developers.bootloader.high_fuses=0xde
+avr_developers.bootloader.extended_fuses=0xfd
+avr_developers.bootloader.unlock_bits=0x3F
+avr_developers.bootloader.lock_bits=0x0F
+avr_developers.build.mcu=atmega1284p
+avr_developers.build.core=arduino:arduino
+avr_developers.build.variant=avr_developers
+
+# 16Mhz Full Swing - more resistant to electrical interference than Low Power
+avr_developers.menu.clock.full_swing=16Mhz Full Swing
+avr_developers.menu.clock.full_swing.upload.speed=115200
+avr_developers.menu.clock.full_swing.bootloader.low_fuses=0xf7
+avr_developers.menu.clock.full_swing.bootloader.file=optiboot/optiboot_atmega1284p.hex
+avr_developers.menu.clock.full_swing.build.f_cpu=16000000L
+
+# 16Mhz Full Swing @ 1Mbps
+avr_developers.menu.clock.1M=16Mhz F.S. @ 1Mbps
+avr_developers.menu.clock.1M.upload.speed=1000000
+avr_developers.menu.clock.1M.bootloader.low_fuses=0xf7
+avr_developers.menu.clock.1M.bootloader.file=optiboot/optiboot_mighty1284p_1M.hex
+avr_developers.menu.clock.1M.build.f_cpu=16000000L
+
+# 16Mhz Low Power
+avr_developers.menu.clock.low_power=16Mhz Low Power
+avr_developers.menu.clock.low_power.upload.speed=115200
+avr_developers.menu.clock.low_power.bootloader.low_fuses=0xff
+avr_developers.menu.clock.low_power.bootloader.file=optiboot/optiboot_atmega1284p.hex
+avr_developers.menu.clock.low_power.build.f_cpu=16000000L
+
+# 8Mhz Internal Oscillator
+avr_developers.menu.clock.8Mhz=8Mhz Internal
+avr_developers.menu.clock.8Mhz.upload.speed=500000
+avr_developers.menu.clock.8Mhz.bootloader.low_fuses=0xe2
+avr_developers.menu.clock.8Mhz.bootloader.file=optiboot/optiboot_1284p_8MHz_500k.hex
+avr_developers.menu.clock.8Mhz.build.f_cpu=8000000L
+
+# 20Mhz Full Swing
+avr_developers.menu.clock.20Mhz=20Mhz Full Swing
+avr_developers.menu.clock.20Mhz.upload.speed=115200
+avr_developers.menu.clock.20Mhz.bootloader.low_fuses=0xf7
+avr_developers.menu.clock.20Mhz.bootloader.file=optiboot/optiboot_atmega1284p.hex
+avr_developers.menu.clock.20Mhz.build.f_cpu=20000000L
+
+##############################################################
+
+bobuino.name=Bobuino or Skinny Bob
+bobuino.upload.tool=arduino:avrdude
+bobuino.upload.protocol=arduino
+bobuino.upload.maximum_data_size=16384
+bobuino.upload.maximum_size=130048
+bobuino.bootloader.tool=arduino:avrdude
+bobuino.bootloader.high_fuses=0xde
+bobuino.bootloader.extended_fuses=0xfd
+bobuino.bootloader.unlock_bits=0x3F
+bobuino.bootloader.lock_bits=0x0F
+bobuino.build.mcu=atmega1284p
+bobuino.build.core=arduino:arduino
+bobuino.build.variant=bobuino
+
+# 16Mhz Full Swing - more resistant to electrical interference than Low Power
+bobuino.menu.clock.full_swing=16Mhz Full Swing
+bobuino.menu.clock.full_swing.upload.speed=115200
+bobuino.menu.clock.full_swing.bootloader.low_fuses=0xf7
+bobuino.menu.clock.full_swing.bootloader.file=optiboot/optiboot_atmega1284p.hex
+bobuino.menu.clock.full_swing.build.f_cpu=16000000L
+
+# 16Mhz Full Swing @ 1Mbps
+bobuino.menu.clock.1M=16Mhz F.S. @ 1Mbps
+bobuino.menu.clock.1M.upload.speed=1000000
+bobuino.menu.clock.1M.bootloader.low_fuses=0xf7
+bobuino.menu.clock.1M.bootloader.file=optiboot/optiboot_mighty1284p_1M.hex
+bobuino.menu.clock.1M.build.f_cpu=16000000L
+
+# 16Mhz Low Power
+bobuino.menu.clock.low_power=16Mhz Low Power
+bobuino.menu.clock.low_power.upload.speed=115200
+bobuino.menu.clock.low_power.bootloader.low_fuses=0xff
+bobuino.menu.clock.low_power.bootloader.file=optiboot/optiboot_atmega1284p.hex
+bobuino.menu.clock.low_power.build.f_cpu=16000000L
+
+# 8Mhz Internal Oscillator
+bobuino.menu.clock.8Mhz=8Mhz Internal
+bobuino.menu.clock.8Mhz.upload.speed=500000
+bobuino.menu.clock.8Mhz.bootloader.low_fuses=0xe2
+bobuino.menu.clock.8Mhz.bootloader.file=optiboot/optiboot_1284p_8MHz_500k.hex
+bobuino.menu.clock.8Mhz.build.f_cpu=8000000L
+
+# 20Mhz Full Swing
+bobuino.menu.clock.20Mhz=20Mhz Full Swing
+bobuino.menu.clock.20Mhz.upload.speed=115200
+bobuino.menu.clock.20Mhz.bootloader.low_fuses=0xf7
+bobuino.menu.clock.20Mhz.bootloader.file=optiboot/optiboot_atmega1284p.hex
+bobuino.menu.clock.20Mhz.build.f_cpu=20000000L
+
+##############################################################
+
+# http://github.com/JChristensen/mini1284
+mighty.name="maniacbug" Mighty 1284P or Mighty Mini 1284P
+mighty.upload.tool=arduino:avrdude
+mighty.upload.protocol=arduino
+mighty.upload.maximum_data_size=16384
+mighty.upload.maximum_size=130048
+mighty.bootloader.tool=arduino:avrdude
+mighty.bootloader.high_fuses=0xde
+mighty.bootloader.extended_fuses=0xfd
+mighty.bootloader.unlock_bits=0x3F
+mighty.bootloader.lock_bits=0x0F
+mighty.build.mcu=atmega1284p
+mighty.build.core=arduino:arduino
+mighty.build.variant=standard
+
+# 16Mhz Full Swing - more resistant to electrical interference than Low Power
+mighty.menu.clock.full_swing=16Mhz Full Swing
+mighty.menu.clock.full_swing.upload.speed=115200
+mighty.menu.clock.full_swing.bootloader.low_fuses=0xf7
+mighty.menu.clock.full_swing.bootloader.file=optiboot/optiboot_atmega1284p.hex
+mighty.menu.clock.full_swing.build.f_cpu=16000000L
+
+# 16Mhz Full Swing @ 1Mbps
+mighty.menu.clock.1M=16Mhz F.S. @ 1Mbps
+mighty.menu.clock.1M.upload.speed=1000000
+mighty.menu.clock.1M.bootloader.low_fuses=0xf7
+mighty.menu.clock.1M.bootloader.file=optiboot/optiboot_mighty1284p_1M.hex
+mighty.menu.clock.1M.build.f_cpu=16000000L
+
+# 16Mhz Low Power
+mighty.menu.clock.low_power=16Mhz Low Power
+mighty.menu.clock.low_power.upload.speed=115200
+mighty.menu.clock.low_power.bootloader.low_fuses=0xff
+mighty.menu.clock.low_power.bootloader.file=optiboot/optiboot_atmega1284p.hex
+mighty.menu.clock.low_power.build.f_cpu=16000000L
+
+# 8Mhz Internal Oscillator
+mighty.menu.clock.8Mhz=8Mhz Internal
+mighty.menu.clock.8Mhz.upload.speed=500000
+mighty.menu.clock.8Mhz.bootloader.low_fuses=0xe2
+mighty.menu.clock.8Mhz.bootloader.file=optiboot/optiboot_1284p_8MHz_500k.hex
+mighty.menu.clock.8Mhz.build.f_cpu=8000000L
+
+# 20Mhz Full Swing
+mighty.menu.clock.20Mhz=20Mhz Full Swing
+mighty.menu.clock.20Mhz.upload.speed=115200
+mighty.menu.clock.20Mhz.bootloader.low_fuses=0xf7
+mighty.menu.clock.20Mhz.bootloader.file=optiboot/optiboot_atmega1284p.hex
+mighty.menu.clock.20Mhz.build.f_cpu=20000000L


### PR DESCRIPTION
boards.txt.alt provides a custom Tools > Clock menu that allows 15 different board
configurations with only 3 Board menu entries.
- Add 16Mhz Full Swing, 16Mhz Full Swing @1Mbps, 16Mhz Low Power, 8Mhz
  Internal, and 20Mhz Full Swing clock options to all boards.
- Combine "maniacbug" Mighty 1284P and Mighty Mini 1284P into one Board
  menu entry.
  ![clock_menu](https://cloud.githubusercontent.com/assets/8572152/7627256/5adf553e-f9ca-11e4-9cf0-78613e789523.jpg)
