### PR TITLE
Unique name value in library.properties

### DIFF
--- a/avr/libraries/Firmata/library.properties
+++ b/avr/libraries/Firmata/library.properties
@@ -1,0 +1,9 @@
+name=Firmata(Mighty 1284P patched version)
+version=2.3.1
+author=Firmata Developers
+maintainer=
+sentence=Enables the communication with computer apps using a standard serial protocol. For all Arduino boards.
+paragraph=The Firmata library implements the Firmata protocol for communicating with software on the host computer. This allows you to write custom firmware without having to create your own protocol and objects for the programming environment that you are using. Patched to support ATmega1284P.
+category=Device Control
+url=https://github.com/JChristensen/mighty-1284p/tree/v1.6.3
+architectures=*

--- a/avr/libraries/SD/library.properties
+++ b/avr/libraries/SD/library.properties
@@ -1,0 +1,9 @@
+name=SD(Mighty 1284P patched version)
+version=1.0.0
+author=Arduino, SparkFun
+maintainer=
+sentence=Enables reading and writing on SD cards. For all Arduino boards.
+paragraph=Once an SD memory card is connected to the SPI interfare of the Arduino board you are enabled to create files and read/write on them. You can also move through directories on the SD card. Patched to support ATmega1284P.
+category=Data Storage
+url=https://github.com/JChristensen/mighty-1284p/tree/v1.6.3
+architectures=*

--- a/avr/libraries/Servo/library.properties
+++ b/avr/libraries/Servo/library.properties
@@ -1,0 +1,9 @@
+name=Servo(Mighty 1284P patched version)
+version=1.0.0
+author=Michael Margolis, Arduino
+maintainer=
+sentence=Allows Arduino boards to control a variety of servo motors. For all Arduino boards.
+paragraph=This library can control a great number of servos.<br />It makes careful use of timers: the library can control 12 servos using only 1 timer.<br />Patched to support ATmega1284P and ATmega1284.
+category=Device Control
+url=https://github.com/JChristensen/mighty-1284p/tree/v1.6.3
+architectures=avr,sam,samd

--- a/avr/patched-3rd-party-libs/SdFat/library.properties
+++ b/avr/patched-3rd-party-libs/SdFat/library.properties
@@ -1,0 +1,9 @@
+name=SdFat(Mighty 1284P patched version)
+version=1.0.0
+author=Bill Greiman
+maintainer=
+sentence=A minimal implementation of FAT16 and FAT32 file systems on SD flash memory cards
+paragraph=Standard SD and high capacity SDHC cards are supported.<br />Patched to support ATmega1284P.
+category=Data Storage
+url=https://github.com/JChristensen/mighty-1284p/tree/v1.6.3
+architectures=*


### PR DESCRIPTION
This pull request fixes a problem with some of the bundled libraries and the Arduino IDE Library Manager.

SD, Servo, and Firmata libraries were appearing as Updatable in Library Manager, and triggering updatable library notifications in Arduino IDE 1.6.6+,  whenever a Mighty 1284P board was selected because they have the same name value(because if no library.properties file is present then the folder name is used). I used version 1.0.0 in library.properties for SD, Servo, and SDfat libraries because I was unable to determine which version they were based on.

This issue exacerbates https://github.com/JChristensen/mighty-1284p/issues/24 because it can cause the user to unnecessarily install the unpatched libraries to their {sketchbook}/libraries folder. This is especially likely with Arduino IDE versions 1.6.6+ because of the updatable library notifications.
