### PR TITLE
Add missing timer definitions to avr_developers variant

### DIFF
--- a/avr/variants/avr_developers/pins_arduino.h
+++ b/avr/variants/avr_developers/pins_arduino.h
@@ -286,8 +286,8 @@ const uint8_t PROGMEM digital_pin_to_timer_PGM[] =
   TIMER0A,     	/* 3  - PB3 */
   TIMER0B,      /* 4  - PB4 */
   NOT_ON_TIMER, /* 5  - PB5 */
-  NOT_ON_TIMER, /* 6  - PB6 */
-  NOT_ON_TIMER,	/* 7  - PB7 */
+  TIMER3A,      /* 6  - PB6 */
+  TIMER3B,      /* 7  - PB7 */
   NOT_ON_TIMER, /* 8  - PD0 */
   NOT_ON_TIMER, /* 9  - PD1 */
   NOT_ON_TIMER, /* 10 - PD2 */


### PR DESCRIPTION
TIMER3A and TIMER3B were missing from avr_developers'
digital_pin_to_timer_PGM which caused PWM not to work on pins 6 and 7.
